### PR TITLE
Implementa o pacote float

### DIFF
--- a/TCC_Template.tex
+++ b/TCC_Template.tex
@@ -19,6 +19,7 @@
 \usepackage{indentfirst}		
 \usepackage{color}			
 \usepackage{graphicx}		
+\usepackage{float}
 \usepackage{microtype} 
 \usepackage{hyperref}
 \usepackage{xurl}


### PR DESCRIPTION
Implementa o pacote float para possibilitar o aluno usar o parametro 'H' em figuras e setar para o Latex não gerenciar o melhor posicionamento daquela figura

Exemplo:
![image](https://user-images.githubusercontent.com/30275723/191640158-170b892d-9374-4028-9ca5-e084b7d857c0.png)
